### PR TITLE
Enable automatic installation during kernel upgrade

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -5,3 +5,4 @@ BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/acpi"
 MAKE[0]="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/src modules"
 CLEAN="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build/src clean"
+AUTOINSTALL=yes


### PR DESCRIPTION
The module did not install in new kernels after kernel upgrades in Debian 11.

With the option
```
AUTOINSTALL=yes
```
in the DKMS file the module is rebuilt and installed automatically when upgrading to a new kernel.